### PR TITLE
Database Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,5 @@ jobs:
       - run: go get github.com/mattn/goveralls
       - run: go get -u github.com/golang/dep/cmd/dep
       - run: dep ensure
-      - run: make test-integration
-      - run: /go/bin/goveralls -service=circle-ci -repotoken=$COVERALLS_TOKEN
+      - run: make test-integration-cover
+      - run: /go/bin/goveralls -coverprofile=coverage-all.out -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,14 @@ jobs:
     docker:
       # specify the version
       - image: circleci/golang:1.9
+
+      - image: postgres:9.5
+        ports:
+          - 5432:5432
+        environment:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: aerogear_mobile_metrics
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -23,5 +31,5 @@ jobs:
       - run: go get github.com/mattn/goveralls
       - run: go get -u github.com/golang/dep/cmd/dep
       - run: dep ensure
-      - run: go test -v -coverpkg=./... ./...
+      - run: make test-integration
       - run: /go/bin/goveralls -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 .idea/
 metrics
 dist/
+coverage*.out

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,9 +19,18 @@
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
+[[projects]]
+  branch = "master"
+  name = "github.com/lib/pq"
+  packages = [
+    ".",
+    "oid"
+  ]
+  revision = "88edab0803230a3898347e77b474f8c1820a1f20"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "09ecedeaf3837572256e692f5337023e880d3e28b02063de6ec115e1984e3c7b"
+  inputs-digest = "9078497a83d301ee5230a5970fc382c993cde488695836a386d83d573a7baae3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "1.1.1"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
@@ -28,9 +34,30 @@
   ]
   revision = "88edab0803230a3898347e77b474f8c1820a1f20"
 
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
+  version = "v0.1"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "mock"
+  ]
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9078497a83d301ee5230a5970fc382c993cde488695836a386d83d573a7baae3"
+  inputs-digest = "c56cca0c33a9947373eeed4372b6600c13eed5ce8389ca649bdb4fb3679f2c66"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,3 +36,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/lib/pq"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,30 +1,3 @@
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
-
-
 [[constraint]]
   name = "github.com/darahayes/go-boom"
   version = "1.0.1"
@@ -40,3 +13,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/lib/pq"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.2.1"

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -40,12 +40,10 @@ func main() {
 		web.HealthzRoute(router, healthHandler)
 	}
 
-	listenAddress := ":3000"
-
-	log.Printf("Starting application... going to listen on %v", listenAddress)
+	log.Printf("Starting application... going to listen on %v", config.ListenAddress)
 
 	//start
-	if err := http.ListenAndServe(listenAddress, router); err != nil {
+	if err := http.ListenAndServe(config.ListenAddress, router); err != nil {
 		panic("failed to start " + err.Error())
 	}
 }

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -16,7 +16,7 @@ func main() {
 
 	dbHandler := dao.DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		panic("failed to connect to sql database : " + err.Error())
@@ -42,10 +42,10 @@ func main() {
 		web.HealthzRoute(router, healthHandler)
 	}
 
-	log.Printf("Starting application... going to listen on %v", config.ListenAddress)
+	log.Printf("Starting application... going to listen on %v", config["ListenAddress"])
 
 	//start
-	if err := http.ListenAndServe(config.ListenAddress, router); err != nil {
+	if err := http.ListenAndServe(config["ListenAddress"], router); err != nil {
 		panic("failed to start " + err.Error())
 	}
 }

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"log"
 	"net/http"
+	"os"
 
 	"github.com/aerogear/aerogear-metrics-api/pkg/dao"
 	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
@@ -9,17 +11,40 @@ import (
 )
 
 func main() {
-	router := web.NewRouter()
-	db, err := dao.Connect()
+
+	// Simple helper function to read an environment or return a default value
+	getEnv := func(key string, defaultVal string) string {
+		if value := os.Getenv(key); value != "" {
+			return value
+		}
+		return defaultVal
+	}
+
+	var (
+		dbHost     = getEnv("PGHOST", "localhost")
+		dbUser     = getEnv("PGPORT", "postgres")
+		dbPassword = getEnv("PGPASSWORD", "postgres")
+		dbName     = getEnv("PGDATABASE", "aerogear_mobile_metrics")
+		sslMode    = getEnv("PGSSLMODE", "disable")
+	)
+
+	db, err := dao.Connect(dbHost, dbUser, dbPassword, dbName, sslMode)
+
 	if err != nil {
 		panic("failed to connect to sql database : " + err.Error())
 	}
 	defer db.Close()
-	metricDao := dao.NewMetricsDAO(db)
+
+	if err := dao.DoInitialSetup(); err != nil {
+		panic("failed to perform database setup : " + err.Error())
+	}
+
+	metricsDao := dao.NewMetricsDAO(db)
+	router := web.NewRouter()
 
 	//metrics route
 	{
-		metricsService := mobile.NewMetricsService(metricDao)
+		metricsService := mobile.NewMetricsService(metricsDao)
 		metricsHandler := web.NewMetricsHandler(metricsService)
 		web.MetricsRoute(router, metricsHandler)
 	}
@@ -29,8 +54,12 @@ func main() {
 		web.HealthzRoute(router, healthHandler)
 	}
 
+	listenAddress := ":3000"
+
+	log.Printf("Starting application... going to listen on %v", listenAddress)
+
 	//start
-	if err := http.ListenAndServe(":3000", router); err != nil {
+	if err := http.ListenAndServe(listenAddress, router); err != nil {
 		panic("failed to start " + err.Error())
 	}
 }

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -14,18 +14,20 @@ func main() {
 
 	config := config.GetConfig()
 
-	db, err := dao.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	dbHandler := dao.DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
 
 	if err != nil {
 		panic("failed to connect to sql database : " + err.Error())
 	}
-	defer db.Close()
+	defer dbHandler.DB.Close()
 
-	if err := dao.DoInitialSetup(); err != nil {
+	if err := dbHandler.DoInitialSetup(); err != nil {
 		panic("failed to perform database setup : " + err.Error())
 	}
 
-	metricsDao := dao.NewMetricsDAO(db)
+	metricsDao := dao.NewMetricsDAO(dbHandler.DB)
 	router := web.NewRouter()
 
 	//metrics route

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -50,7 +50,7 @@ func main() {
 	}
 	//health route
 	{
-		healthHandler := web.NewHealthHandler()
+		healthHandler := web.NewHealthHandler(metricsDao)
 		web.HealthzRoute(router, healthHandler)
 	}
 

--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -3,8 +3,8 @@ package main
 import (
 	"log"
 	"net/http"
-	"os"
 
+	"github.com/aerogear/aerogear-metrics-api/pkg/config"
 	"github.com/aerogear/aerogear-metrics-api/pkg/dao"
 	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 	"github.com/aerogear/aerogear-metrics-api/pkg/web"
@@ -12,23 +12,9 @@ import (
 
 func main() {
 
-	// Simple helper function to read an environment or return a default value
-	getEnv := func(key string, defaultVal string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultVal
-	}
+	config := config.GetConfig()
 
-	var (
-		dbHost     = getEnv("PGHOST", "localhost")
-		dbUser     = getEnv("PGPORT", "postgres")
-		dbPassword = getEnv("PGPASSWORD", "postgres")
-		dbName     = getEnv("PGDATABASE", "aerogear_mobile_metrics")
-		sslMode    = getEnv("PGSSLMODE", "disable")
-	)
-
-	db, err := dao.Connect(dbHost, dbUser, dbPassword, dbName, sslMode)
+	db, err := dao.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
 
 	if err != nil {
 		panic("failed to connect to sql database : " + err.Error())

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -6,5 +6,4 @@ postgres:
     POSTGRES_PASSWORD: postgres
     POSTGRES_USER: postgres
     PGDATA : /var/lib/postgresql/data/pgdata
-  volumes:
-    - psqlvolumes:/var/lib/postgresql/data/pgdata
+    PGDATABASE: aerogear_mobile_metrics

--- a/deployments/docker/docker-compose.yml
+++ b/deployments/docker/docker-compose.yml
@@ -1,9 +1,8 @@
 postgres:
-  image: timescale/timescaledb
+  image: postgres:9.5
   ports:
     - 5432:5432
   environment:
     POSTGRES_PASSWORD: postgres
     POSTGRES_USER: postgres
-    PGDATA : /var/lib/postgresql/data/pgdata
-    PGDATABASE: aerogear_mobile_metrics
+    POSTGRES_DB: aerogear_mobile_metrics

--- a/makefile
+++ b/makefile
@@ -1,9 +1,12 @@
 PKG     = github.com/aerogear/aerogear-metrics-api
+TOP_SRC_DIRS   = pkg
+PACKAGES     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
+                   -exec dirname {} \\; | sort | uniq")
 BIN_DIR := $(GOPATH)/bin
 SHELL = /bin/bash
 BINARY = metrics
 
-LDFLAGS=-ldflags "-w -s -X main.Version=$(TAG)"
+LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 
 .PHONY: setup
 setup:
@@ -23,12 +26,21 @@ build_binary:
 .PHONY: test-unit
 test-unit:
 	@echo Running tests:
-	go test -v -race -coverpkg=./... ./...
+	go test -v -race -cover $(UNIT_TEST_FLAGS) \
+	  $(addprefix $(PKG)/,$(PACKAGES))
 
 .PHONY: test-integration
 test-integration:
 	@echo Running tests:
-	go test -v -race -tags=integration -coverpkg=./... ./...
+	go test -v -race -cover $(UNIT_TEST_FLAGS) -tags=integration \
+	  $(addprefix $(PKG)/,$(PACKAGES))
+
+.PHONY: test-integration-cover
+test-integration-cover:
+	echo "mode: count" > coverage-all.out
+	$(foreach pkg,$(PACKAGES),\
+		go test -tags=integration -coverprofile=coverage.out -covermode=count $(addprefix $(PKG)/,$(pkg));\
+		tail -n +2 coverage.out >> coverage-all.out;)
 
 .PHONY: errcheck
 errcheck:
@@ -47,7 +59,7 @@ fmt:
 
 .PHONY: clean
 clean:
-	-rm -f $(BINARY)
+	-rm -f ${BINARY}
 
 .PHONY: release
 release: setup

--- a/makefile
+++ b/makefile
@@ -1,12 +1,9 @@
 PKG     = github.com/aerogear/aerogear-metrics-api
-TOP_SRC_DIRS   = pkg
-TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
-                   -exec dirname {} \\; | sort | uniq")
 BIN_DIR := $(GOPATH)/bin
 SHELL = /bin/bash
 BINARY = metrics
 
-LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
+LDFLAGS=-ldflags "-w -s -X main.Version=$(TAG)"
 
 .PHONY: setup
 setup:
@@ -26,8 +23,12 @@ build_binary:
 .PHONY: test-unit
 test-unit:
 	@echo Running tests:
-	go test -v -race -cover $(UNIT_TEST_FLAGS) \
-	  $(addprefix $(PKG)/,$(TEST_DIRS))
+	go test -v -race -coverpkg=./... ./...
+
+.PHONY: test-integration
+test-integration:
+	@echo Running tests:
+	go test -v -race -tags=integration -coverpkg=./... ./...
 
 .PHONY: errcheck
 errcheck:
@@ -46,7 +47,7 @@ fmt:
 
 .PHONY: clean
 clean:
-	-rm -f ${BINARY}
+	-rm -f $(BINARY)
 
 .PHONY: release
 release: setup

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import "os"
+
+type config struct {
+	DBHost     string
+	DBUser     string
+	DBPassword string
+	DBName     string
+	SSLMode    string
+}
+
+// Simple helper function to read an environment or return a default value
+func getEnv(key string, defaultVal string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultVal
+}
+
+func GetConfig() *config {
+	return &config{
+		DBHost:     getEnv("PGHOST", "localhost"),
+		DBUser:     getEnv("PGPORT", "postgres"),
+		DBPassword: getEnv("PGPASSWORD", "postgres"),
+		DBName:     getEnv("PGDATABASE", "aerogear_mobile_metrics"),
+		SSLMode:    getEnv("PGSSLMODE", "disable"),
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,13 +1,17 @@
 package config
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 type config struct {
-	DBHost     string
-	DBUser     string
-	DBPassword string
-	DBName     string
-	SSLMode    string
+	DBHost        string
+	DBUser        string
+	DBPassword    string
+	DBName        string
+	SSLMode       string
+	ListenAddress string
 }
 
 // Simple helper function to read an environment or return a default value
@@ -20,10 +24,11 @@ func getEnv(key string, defaultVal string) string {
 
 func GetConfig() *config {
 	return &config{
-		DBHost:     getEnv("PGHOST", "localhost"),
-		DBUser:     getEnv("PGPORT", "postgres"),
-		DBPassword: getEnv("PGPASSWORD", "postgres"),
-		DBName:     getEnv("PGDATABASE", "aerogear_mobile_metrics"),
-		SSLMode:    getEnv("PGSSLMODE", "disable"),
+		DBHost:        getEnv("PGHOST", "localhost"),
+		DBUser:        getEnv("PGPORT", "postgres"),
+		DBPassword:    getEnv("PGPASSWORD", "postgres"),
+		DBName:        getEnv("PGDATABASE", "aerogear_mobile_metrics"),
+		SSLMode:       getEnv("PGSSLMODE", "disable"),
+		ListenAddress: fmt.Sprintf(":%s", getEnv("PORT", "3000")),
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,15 +5,6 @@ import (
 	"os"
 )
 
-type config struct {
-	DBHost        string
-	DBUser        string
-	DBPassword    string
-	DBName        string
-	SSLMode       string
-	ListenAddress string
-}
-
 // Simple helper function to read an environment or return a default value
 func getEnv(key string, defaultVal string) string {
 	if value := os.Getenv(key); value != "" {
@@ -22,13 +13,13 @@ func getEnv(key string, defaultVal string) string {
 	return defaultVal
 }
 
-func GetConfig() *config {
-	return &config{
-		DBHost:        getEnv("PGHOST", "localhost"),
-		DBUser:        getEnv("PGUSER", "postgres"),
-		DBPassword:    getEnv("PGPASSWORD", "postgres"),
-		DBName:        getEnv("PGDATABASE", "aerogear_mobile_metrics"),
-		SSLMode:       getEnv("PGSSLMODE", "disable"),
-		ListenAddress: fmt.Sprintf(":%s", getEnv("PORT", "3000")),
+func GetConfig() map[string]string {
+	return map[string]string{
+		"DBHost":        getEnv("PGHOST", "localhost"),
+		"DBUser":        getEnv("PGUSER", "postgres"),
+		"DBPassword":    getEnv("PGPASSWORD", "postgres"),
+		"DBName":        getEnv("PGDATABASE", "aerogear_mobile_metrics"),
+		"SSLMode":       getEnv("PGSSLMODE", "disable"),
+		"ListenAddress": fmt.Sprintf(":%s", getEnv("PORT", "3000")),
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ func getEnv(key string, defaultVal string) string {
 func GetConfig() *config {
 	return &config{
 		DBHost:        getEnv("PGHOST", "localhost"),
-		DBUser:        getEnv("PGPORT", "postgres"),
+		DBUser:        getEnv("PGUSER", "postgres"),
 		DBPassword:    getEnv("PGPASSWORD", "postgres"),
 		DBName:        getEnv("PGDATABASE", "aerogear_mobile_metrics"),
 		SSLMode:       getEnv("PGSSLMODE", "disable"),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,15 +1,10 @@
 package config
 
 import (
-	"fmt"
 	"os"
 	"reflect"
 	"testing"
 )
-
-func TestgetEnv(t *testing.T) {
-
-}
 
 func TestGetConfig(t *testing.T) {
 	expected := map[string]string{
@@ -47,8 +42,6 @@ func TestGetConfigCustomEnvVariables(t *testing.T) {
 
 	config := GetConfig()
 
-	fmt.Println(config)
-
 	if !reflect.DeepEqual(config, expected) {
 		t.Error("GetConfig() did not return expected result")
 	}
@@ -72,8 +65,6 @@ func TestGetConfigEmptyEnvVariables(t *testing.T) {
 	os.Setenv("PORT", "")
 
 	config := GetConfig()
-
-	fmt.Println(config)
 
 	if !reflect.DeepEqual(config, expected) {
 		t.Error("GetConfig() did not return expected result")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestgetEnv(t *testing.T) {
+
+}
+
+func TestGetConfig(t *testing.T) {
+	expected := map[string]string{
+		"DBHost":        "localhost",
+		"DBUser":        "postgres",
+		"DBPassword":    "postgres",
+		"DBName":        "aerogear_mobile_metrics",
+		"SSLMode":       "disable",
+		"ListenAddress": ":3000",
+	}
+
+	config := GetConfig()
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Error("GetConfig() did not return expected result")
+	}
+}
+
+func TestGetConfigCustomEnvVariables(t *testing.T) {
+	expected := map[string]string{
+		"DBHost":        "testing",
+		"DBUser":        "testing",
+		"DBPassword":    "testing",
+		"DBName":        "testing",
+		"SSLMode":       "testing",
+		"ListenAddress": ":testing",
+	}
+
+	os.Setenv("PGHOST", "testing")
+	os.Setenv("PGUSER", "testing")
+	os.Setenv("PGPASSWORD", "testing")
+	os.Setenv("PGDATABASE", "testing")
+	os.Setenv("PGSSLMODE", "testing")
+	os.Setenv("PORT", "testing")
+
+	config := GetConfig()
+
+	fmt.Println(config)
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Error("GetConfig() did not return expected result")
+	}
+}
+
+func TestGetConfigEmptyEnvVariables(t *testing.T) {
+	expected := map[string]string{
+		"DBHost":        "localhost",
+		"DBUser":        "postgres",
+		"DBPassword":    "postgres",
+		"DBName":        "aerogear_mobile_metrics",
+		"SSLMode":       "disable",
+		"ListenAddress": ":3000",
+	}
+
+	os.Setenv("PGHOST", "")
+	os.Setenv("PGUSER", "")
+	os.Setenv("PGPASSWORD", "")
+	os.Setenv("PGDATABASE", "")
+	os.Setenv("PGSSLMODE", "")
+	os.Setenv("PORT", "")
+
+	config := GetConfig()
+
+	fmt.Println(config)
+
+	if !reflect.DeepEqual(config, expected) {
+		t.Error("GetConfig() did not return expected result")
+	}
+}

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -16,18 +16,6 @@ func (m *MetricsDAO) Create(metric mobile.Metric) (mobile.Metric, error) {
 	return metric, errors.New("Not Implemented yet")
 }
 
-// Update an existing job
-// Not sure if we need this
-func (m *MetricsDAO) Update() {
-
-}
-
-// Delete an existing job
-// Not sure if we need this
-func (m *MetricsDAO) Delete() {
-
-}
-
 // Ping checks that we are connected to the database
 // This will be used by the healthcheck
 func (m *MetricsDAO) Ping() error {

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -2,9 +2,6 @@ package dao
 
 import (
 	"database/sql"
-	"encoding/json"
-
-	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 )
 
 type MetricsDAO struct {
@@ -12,14 +9,8 @@ type MetricsDAO struct {
 }
 
 // Create a metrics record
-func (m *MetricsDAO) Create(metric mobile.Metric) error {
-	data, err := json.Marshal(metric.Data)
-
-	if err != nil {
-		return err
-	}
-
-	_, err = db.Exec("INSERT INTO mobileappmetrics(clientId, data) VALUES($1, $2)", metric.ClientId, data)
+func (m *MetricsDAO) Create(clientId string, metricsData []byte) error {
+	_, err := db.Exec("INSERT INTO mobileappmetrics(clientId, data) VALUES($1, $2)", clientId, metricsData)
 	return err
 }
 

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -28,10 +28,10 @@ func (m *MetricsDAO) Delete() {
 
 }
 
-// CheckConnection checks that we are connected to the database
+// Ping checks that we are connected to the database
 // This will be used by the healthcheck
-func (m *MetricsDAO) CheckConnection() {
-
+func (m *MetricsDAO) Ping() error {
+	return m.db.Ping()
 }
 
 func NewMetricsDAO(db *sql.DB) *MetricsDAO {

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -10,7 +10,7 @@ type MetricsDAO struct {
 
 // Create a metrics record
 func (m *MetricsDAO) Create(clientId string, metricsData []byte) error {
-	_, err := db.Exec("INSERT INTO mobileappmetrics(clientId, data) VALUES($1, $2)", clientId, metricsData)
+	_, err := m.db.Exec("INSERT INTO mobileappmetrics(clientId, data) VALUES($1, $2)", clientId, metricsData)
 	return err
 }
 

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -2,7 +2,7 @@ package dao
 
 import (
 	"database/sql"
-	"errors"
+	"encoding/json"
 
 	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 )
@@ -12,8 +12,15 @@ type MetricsDAO struct {
 }
 
 // Create a metrics record
-func (m *MetricsDAO) Create(metric mobile.Metric) (mobile.Metric, error) {
-	return metric, errors.New("Not Implemented yet")
+func (m *MetricsDAO) Create(metric mobile.Metric) error {
+	data, err := json.Marshal(metric.Data)
+
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Exec("INSERT INTO mobileappmetrics(clientId, data) VALUES($1, $2)", metric.ClientId, data)
+	return err
 }
 
 // Ping checks that we are connected to the database

--- a/pkg/dao/dao.go
+++ b/pkg/dao/dao.go
@@ -14,10 +14,11 @@ func (m *MetricsDAO) Create(clientId string, metricsData []byte) error {
 	return err
 }
 
-// Ping checks that we are connected to the database
+// IsHealthy checks that we are connected to the database
 // This will be used by the healthcheck
-func (m *MetricsDAO) Ping() error {
-	return m.db.Ping()
+func (m *MetricsDAO) IsHealthy() (bool, error) {
+	err := m.db.Ping()
+	return err == nil, err
 }
 
 func NewMetricsDAO(db *sql.DB) *MetricsDAO {

--- a/pkg/dao/dao_test.go
+++ b/pkg/dao/dao_test.go
@@ -116,6 +116,11 @@ func TestCreateEmptyClientID(t *testing.T) {
 	dbHandler := DatabaseHandler{}
 
 	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
 	dbHandler.DoInitialSetup()
 
 	if err != nil {

--- a/pkg/dao/dao_test.go
+++ b/pkg/dao/dao_test.go
@@ -13,7 +13,7 @@ type MockDB struct {
 	mock.Mock
 }
 
-func TestIshealthy(t *testing.T) {
+func TestIsHealthy(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
@@ -36,7 +36,7 @@ func TestIshealthy(t *testing.T) {
 	}
 }
 
-func TestIshealthyWhenDisconnected(t *testing.T) {
+func TestIsHealthyWhenDisconnected(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
@@ -66,6 +66,11 @@ func TestCreate(t *testing.T) {
 	dbHandler := DatabaseHandler{}
 
 	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
 	dbHandler.DoInitialSetup()
 
 	if err != nil {

--- a/pkg/dao/dao_test.go
+++ b/pkg/dao/dao_test.go
@@ -1,0 +1,130 @@
+// +build integration
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/aerogear/aerogear-metrics-api/pkg/config"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockDB struct {
+	mock.Mock
+}
+
+func TestIshealthy(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	dao := NewMetricsDAO(dbHandler.DB)
+
+	isHealthy, err := dao.IsHealthy()
+
+	if err != nil {
+		t.Errorf("isHealthy returned an error %s", err.Error())
+	}
+
+	if !isHealthy {
+		t.Errorf("isHealthy returned false")
+	}
+}
+
+func TestIshealthyWhenDisconnected(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	dao := NewMetricsDAO(dbHandler.DB)
+
+	dbHandler.Disconnect()
+
+	isHealthy, err := dao.IsHealthy()
+
+	if err == nil {
+		t.Errorf("isHealthy returned no error when disconnected")
+	}
+
+	if isHealthy {
+		t.Errorf("isHealthy returned true when disconnected")
+	}
+}
+
+func TestCreate(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	dbHandler.DoInitialSetup()
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	dao := NewMetricsDAO(dbHandler.DB)
+
+	clientId := "org.aerogear.metrics.testing"
+	metricsData := []byte("{\"app\":{\"id\":\"com.example.someApp\",\"sdkVersion\":\"2.4.6\",\"appVersion\":\"256\"},\"device\":{\"platform\":\"android\",\"platformVersion\":\"27\"}}")
+
+	err = dao.Create(clientId, metricsData)
+
+	if err != nil {
+		t.Errorf("Create() returned an error %s", err.Error())
+	}
+}
+
+func TestCreateBadJSON(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	dao := NewMetricsDAO(dbHandler.DB)
+
+	clientId := "org.aerogear.metrics.testing"
+	metricsData := []byte("InvalidJSON")
+
+	err = dao.Create(clientId, metricsData)
+
+	if err == nil {
+		t.Errorf("Create() with invalid JSON did not return an error")
+	}
+}
+
+func TestCreateEmptyClientID(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	dbHandler.DoInitialSetup()
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	dao := NewMetricsDAO(dbHandler.DB)
+
+	clientId := ""
+	metricsData := []byte("{\"app\":{\"id\":\"com.example.someApp\",\"sdkVersion\":\"2.4.6\",\"appVersion\":\"256\"},\"device\":{\"platform\":\"android\",\"platformVersion\":\"27\"}}")
+
+	err = dao.Create(clientId, metricsData)
+
+	if err == nil {
+		t.Errorf("Create() with empty clientId did not return an error")
+	}
+}

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -1,20 +1,56 @@
 package dao
 
-import "database/sql"
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+
+	_ "github.com/lib/pq"
+)
 
 var db *sql.DB
 
-func Connect() (*sql.DB, error) {
+func Connect(dbHost, dbUser, dbPassword, dbName, sslMode string) (*sql.DB, error) {
 	if db != nil {
 		return db, nil
 	}
 	//connection logic
-	return nil, nil
+	connStr := fmt.Sprintf("host=%v user=%v password=%v dbname=%v sslmode=%v", dbHost, dbUser, dbPassword, dbName, sslMode)
+
+	// sql.Open doesn't initialize the connection immediately
+	dbInstance, err := sql.Open("postgres", connStr)
+
+	// an error can happen here if the connection string is invalid
+	if err != nil {
+		return nil, err
+	}
+
+	// an error happens here if we cannot connect
+	if err = dbInstance.Ping(); err != nil {
+		return nil, err
+	}
+
+	// assign db variable declared above
+	db = dbInstance
+	return dbInstance, nil
 }
 
 func Disconnect() error {
-	if nil != db {
+	if db != nil {
 		return db.Close()
+	}
+	return nil
+}
+
+func DoInitialSetup() error {
+	if db == nil {
+		return errors.New("cannot setup database, must call Connect() first")
+	}
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS sdkVersionForClient(clientId varchar(10) not null primary key, version varchar(40) not null, event_time timestamp with time zone)"); err != nil {
+		return err
+	}
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS mobileAppMetrics(clientId varchar(10) not null, event_time timestamp with time zone not null, data jsonb)"); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -46,10 +46,7 @@ func DoInitialSetup() error {
 	if db == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS sdkVersionForClient(clientId varchar(10) not null primary key, version varchar(40) not null, event_time timestamp with time zone)"); err != nil {
-		return err
-	}
-	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS mobileAppMetrics(clientId varchar(10) not null, event_time timestamp with time zone not null, data jsonb)"); err != nil {
+	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(30) NOT NULL, event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -12,11 +12,13 @@ type DatabaseHandler struct {
 	DB *sql.DB
 }
 
+const mobileMetricsTable = "mobileappmetrics"
+
 func (handler *DatabaseHandler) Connect(dbHost, dbUser, dbPassword, dbName, sslMode string) error {
 	if handler.DB != nil {
 		return nil
 	}
-	//connection logic
+
 	connStr := fmt.Sprintf("host=%v user=%v password=%v dbname=%v sslmode=%v", dbHost, dbUser, dbPassword, dbName, sslMode)
 
 	// sql.Open doesn't initialize the connection immediately
@@ -32,7 +34,6 @@ func (handler *DatabaseHandler) Connect(dbHost, dbUser, dbPassword, dbName, sslM
 		return err
 	}
 
-	// assign db variable declared above
 	handler.DB = dbInstance
 	return nil
 }

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -46,9 +46,6 @@ func DoInitialSetup() error {
 	if db == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
-	if _, err := db.Exec("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"); err != nil {
-		return err
-	}
 	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(30) NOT NULL, event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -46,6 +46,9 @@ func DoInitialSetup() error {
 	if db == nil {
 		return errors.New("cannot setup database, must call Connect() first")
 	}
+	if _, err := db.Exec("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;"); err != nil {
+		return err
+	}
 	if _, err := db.Exec("CREATE TABLE IF NOT EXISTS mobileappmetrics(clientId varchar(30) NOT NULL, event_time timestamptz NOT NULL DEFAULT now() Not NULL, data jsonb)"); err != nil {
 		return err
 	}

--- a/pkg/dao/db.go
+++ b/pkg/dao/db.go
@@ -8,8 +8,6 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// var db *sql.DB
-
 type DatabaseHandler struct {
 	DB *sql.DB
 }

--- a/pkg/dao/db_test.go
+++ b/pkg/dao/db_test.go
@@ -1,0 +1,115 @@
+// +build integration
+
+package dao
+
+import (
+	"testing"
+
+	"github.com/aerogear/aerogear-metrics-api/pkg/config"
+)
+
+func TestConnect(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	err = dbHandler.DB.Ping()
+
+	if err != nil {
+		t.Errorf("Failed to Ping the database after Connect(): %s", err.Error())
+	}
+}
+
+func TestConnectAlreadyConnected(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	err = dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+}
+
+func TestDisconnect(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	err = dbHandler.Disconnect()
+
+	if err != nil {
+		t.Errorf("Disconnect() returned an error: %s", err.Error())
+	}
+
+	err = dbHandler.DB.Ping()
+
+	if err == nil {
+		t.Errorf("Ping did not return an error after calling Disconnect()")
+	}
+}
+
+func TestDisconnectNotConnected(t *testing.T) {
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Disconnect()
+
+	if err != nil {
+		t.Errorf("Disconnect() returned an error: %s", err.Error())
+	}
+}
+
+func TestDoInitialSetup(t *testing.T) {
+	config := config.GetConfig()
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+
+	if err != nil {
+		t.Errorf("Connect() returned an error: %s", err.Error())
+	}
+
+	err = dbHandler.DoInitialSetup()
+
+	if err != nil {
+		t.Errorf("DoInitialSetup() returned an error: %s", err.Error())
+	}
+
+	var exists bool
+
+	err = dbHandler.DB.QueryRow("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'mobileappmetrics');").Scan(&exists)
+
+	if err != nil {
+		t.Errorf("Database returned an error while checking if table exists: %s", err.Error())
+	}
+
+	if !exists {
+		t.Errorf("Expected table mobileappmetrics does not exist")
+	}
+}
+
+func TestDoInitialSetupNotConnected(t *testing.T) {
+	dbHandler := DatabaseHandler{}
+
+	err := dbHandler.DoInitialSetup()
+
+	if err == nil {
+		t.Errorf("DoInitialSetup did not return an error")
+	}
+}

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -2,5 +2,5 @@ package mobile
 
 // MetricCreator defines how a metric can be created
 type MetricCreator interface {
-	Create(m Metric) error
+	Create(clientId string, metricsData []byte) error
 }

--- a/pkg/mobile/interfaces.go
+++ b/pkg/mobile/interfaces.go
@@ -2,5 +2,5 @@ package mobile
 
 // MetricCreator defines how a metric can be created
 type MetricCreator interface {
-	Create(m Metric) (Metric, error)
+	Create(m Metric) error
 }

--- a/pkg/mobile/metrics.go
+++ b/pkg/mobile/metrics.go
@@ -11,7 +11,6 @@ func NewMetricsService(dao MetricCreator) *MetricsService {
 }
 
 func (m MetricsService) Create(metric Metric) (Metric, error) {
-
 	metricsData, err := json.Marshal(metric.Data)
 
 	if err != nil {

--- a/pkg/mobile/metrics.go
+++ b/pkg/mobile/metrics.go
@@ -1,9 +1,5 @@
 package mobile
 
-import (
-	"errors"
-)
-
 type MetricsService struct {
 	mdao MetricCreator
 }
@@ -13,5 +9,5 @@ func NewMetricsService(dao MetricCreator) *MetricsService {
 }
 
 func (m MetricsService) Create(metric Metric) (Metric, error) {
-	return metric, errors.New("This is an error")
+	return metric, nil
 }

--- a/pkg/mobile/metrics.go
+++ b/pkg/mobile/metrics.go
@@ -1,5 +1,7 @@
 package mobile
 
+import "encoding/json"
+
 type MetricsService struct {
 	mdao MetricCreator
 }
@@ -9,5 +11,12 @@ func NewMetricsService(dao MetricCreator) *MetricsService {
 }
 
 func (m MetricsService) Create(metric Metric) (Metric, error) {
-	return metric, m.mdao.Create(metric)
+
+	metricsData, err := json.Marshal(metric.Data)
+
+	if err != nil {
+		return metric, err
+	}
+
+	return metric, m.mdao.Create(metric.ClientId, metricsData)
 }

--- a/pkg/mobile/metrics.go
+++ b/pkg/mobile/metrics.go
@@ -9,5 +9,5 @@ func NewMetricsService(dao MetricCreator) *MetricsService {
 }
 
 func (m MetricsService) Create(metric Metric) (Metric, error) {
-	return metric, nil
+	return metric, m.mdao.Create(metric)
 }

--- a/pkg/mobile/metrics_test.go
+++ b/pkg/mobile/metrics_test.go
@@ -1,0 +1,102 @@
+package mobile
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+type MetricsDAOMock struct {
+	mock.Mock
+}
+
+func (m *MetricsDAOMock) Create(clientId string, metricsData []byte) error {
+	args := m.Called(clientId, metricsData)
+	return args.Error(0)
+}
+
+func newTestMetricsService() (*MetricsDAOMock, *MetricsService) {
+	mdaoMock := MetricsDAOMock{}
+
+	ms := NewMetricsService(&mdaoMock)
+
+	return &mdaoMock, ms
+}
+
+func TestCreateCallsDAOWithCorrectArgs(t *testing.T) {
+
+	metric := Metric{
+		ClientId: "org.aerogear.metrics.tests",
+		Data: MetricData{
+			App: AppMetric{
+				ID:         "12345678",
+				SDKVersion: "1.0.0",
+				AppVersion: "1",
+			},
+			Device: DeviceMetric{
+				Platform:        "Android",
+				PlatformVersion: "27",
+			},
+		},
+	}
+	expectedMetricsData, err := json.Marshal(metric.Data)
+
+	if err != nil {
+		t.Errorf("could not encode metric object to JSON")
+	}
+
+	mdaoMock, ms := newTestMetricsService()
+
+	mdaoMock.On("Create", metric.ClientId, expectedMetricsData).Return(nil)
+
+	res, err := ms.Create(metric)
+
+	if err != nil {
+		t.Errorf("Metrics Service should not have returned an error")
+	}
+
+	if reflect.DeepEqual(reflect.ValueOf(metric), reflect.ValueOf(res)) {
+		t.Errorf("failed")
+	}
+
+	mdaoMock.AssertExpectations(t)
+}
+
+func TestCreateReturnsErrorFromDAO(t *testing.T) {
+
+	metric := Metric{
+		ClientId: "org.aerogear.metrics.tests",
+		Data: MetricData{
+			App: AppMetric{
+				ID:         "12345678",
+				SDKVersion: "1.0.0",
+				AppVersion: "1",
+			},
+			Device: DeviceMetric{
+				Platform:        "Android",
+				PlatformVersion: "27",
+			},
+		},
+	}
+	expectedMetricsData, err := json.Marshal(metric.Data)
+
+	if err != nil {
+		t.Errorf("could not encode metric object to JSON")
+	}
+
+	mdaoMock, ms := newTestMetricsService()
+
+	daoError := errors.New("problem connecting to db")
+	mdaoMock.On("Create", metric.ClientId, expectedMetricsData).Return(daoError)
+
+	_, err = ms.Create(metric)
+
+	if err.Error() != daoError.Error() {
+		t.Errorf("Metrics Service did not return the error from the DAO")
+	}
+
+	mdaoMock.AssertExpectations(t)
+}

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -7,10 +7,14 @@ type AppConfig struct {
 // ClientMetric struct is what the client payload should be parsed into
 // Need to figure out how to structure this
 type Metric struct {
-	ClientTimestamp int64        `json:"timestamp"`
-	ClientId        string       `json:"clientId"`
-	App             AppMetric    `json:"app"`
-	Device          DeviceMetric `json:"device"`
+	ClientTimestamp int64      `json:"timestamp"`
+	ClientId        string     `json:"clientId"`
+	Data            MetricData `json:"data"`
+}
+
+type MetricData struct {
+	App    AppMetric    `json:"app"`
+	Device DeviceMetric `json:"device"`
 }
 
 type AppMetric struct {

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -1,7 +1,5 @@
 package mobile
 
-import "time"
-
 type AppConfig struct {
 	DBConnectionString string
 }
@@ -9,7 +7,19 @@ type AppConfig struct {
 // ClientMetric struct is what the client payload should be parsed into
 // Need to figure out how to structure this
 type Metric struct {
-	Timestamp time.Time   `json:"timestamp"`
-	ClientID  string      `json:"clientId"`
-	Data      interface{} `json:"data"`
+	ClientTimestamp int64        `json:"timestamp"`
+	ClientId        string       `json:"clientId"`
+	App             AppMetric    `json:"app"`
+	Device          DeviceMetric `json:"device"`
+}
+
+type AppMetric struct {
+	ID         string `json:"id"`
+	SDKVersion string `json:"sdkVersion"`
+	AppVersion string `json:"appVersion"`
+}
+
+type DeviceMetric struct {
+	Platform        string `json:"platform"`
+	PlatformVersion string `json:"platformVersion"`
 }

--- a/pkg/web/healthzHandler.go
+++ b/pkg/web/healthzHandler.go
@@ -3,6 +3,8 @@ package web
 import (
 	"net/http"
 	"time"
+
+	"github.com/darahayes/go-boom"
 )
 
 // not reusable type so make it package local
@@ -13,12 +15,20 @@ type healthResponse struct {
 }
 
 type healthHandler struct {
+	healthCheckTarget HealthCheckable
 }
 
-func NewHealthHandler() *healthHandler {
-	return &healthHandler{}
+// NewHealthHandler creates a handler for the Health endpoints
+// healthCheckTarget must contain an implementation that will be utilized to signal that
+// the service is ready to accept requests.
+func NewHealthHandler(healthCheckTarget HealthCheckable) *healthHandler {
+	return &healthHandler{
+		healthCheckTarget: healthCheckTarget,
+	}
 }
 
+// Healthz is the implementation for a liveness endpoint.
+// It signals the process is up and running but doesn't guarantee connectivity
 func (hh *healthHandler) Healthz(w http.ResponseWriter, r *http.Request) {
 	status := healthResponse{
 		Timestamp: time.Now().UTC(),
@@ -31,6 +41,22 @@ func (hh *healthHandler) Healthz(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// Ping is the implementation for a readiness endpoint.
+// It signals this process is ready to accept connections
+// and respond to API requests
 func (hh *healthHandler) Ping(w http.ResponseWriter, r *http.Request) {
+	healthy, _ := hh.healthCheckTarget.IsHealthy()
+	if !healthy {
+		boom.ServerUnavailable(w)
+		return
+	}
 
+	status := healthResponse{
+		Timestamp: time.Now().UTC(),
+		Status:    "ok",
+	}
+	if err := withJSON(w, 200, status); err != nil {
+		boom.Internal(w)
+		return
+	}
 }

--- a/pkg/web/healthzHandler_test.go
+++ b/pkg/web/healthzHandler_test.go
@@ -1,35 +1,80 @@
 package web
 
 import (
+	"errors"
 	"testing"
 
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func TestHealthz(t *testing.T) {
-	router := NewRouter()
-	healthHandler := NewHealthHandler()
-	HealthzRoute(router, healthHandler)
-	s := httptest.NewServer(router)
-	defer s.Close()
-	res, err := http.Get(s.URL + "/healthz")
-	if err != nil {
-		t.Fatal("did not expect an error getting healthz", err)
+// MockHealthCheckable implements HealthCheckable interface
+type MockHealthCheckable struct {
+	mock.Mock
+}
+
+// IsHealthy provides a mock function with given fields:
+func (_m *MockHealthCheckable) IsHealthy() (bool, error) {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
-	defer res.Body.Close()
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func TestHealthz(t *testing.T) {
+	checkable := &MockHealthCheckable{}
+
+	healthHandler := NewHealthHandler(checkable)
+
+	assert.HTTPSuccess(t, healthHandler.Healthz, "GET", "/healthz", nil, nil)
+	checkable.AssertExpectations(t)
+}
+
+func TestHealthzPing(t *testing.T) {
+	checkable := &MockHealthCheckable{}
+
+	checkable.On("IsHealthy").Return(true, nil).Times(1)
+	checkable.On("IsHealthy").Return(false, errors.New("db offline")).Times(1)
+
+	healthHandler := NewHealthHandler(checkable)
+
+	assert.HTTPSuccess(t, healthHandler.Ping, "GET", "/healthz/ping", nil, nil)
+	assert.HTTPError(t, healthHandler.Ping, "GET", "/healthz/ping", nil, nil)
+
+	checkable.AssertExpectations(t)
+}
+
+func expectOkayHealthResponse(handler http.HandlerFunc, url string, t *testing.T) {
+	request := httptest.NewRequest("GET", url, nil)
+	w := httptest.NewRecorder()
+	handler(w, request)
+
+	res := w.Result()
 	body, err := ioutil.ReadAll(res.Body)
+	assert.Nil(t, err)
 
 	response := &healthResponse{}
-
 	if err := json.Unmarshal(body, response); err != nil {
 		t.Fatal("failed to unmarshal response body", err)
 	}
 
-	if response.Status != "ok" {
-		t.Fatal("expected an ok status")
-	}
-
+	assert.Equal(t, 200, res.StatusCode)
 }

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -1,0 +1,11 @@
+package web
+
+import "github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+
+type MetricsServiceInterface interface {
+	Create(m mobile.Metric) (mobile.Metric, error)
+}
+
+type HealthCheckable interface {
+	IsHealthy() (bool, error)
+}

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -9,10 +9,10 @@ import (
 )
 
 type metricsHandler struct {
-	metricService *mobile.MetricsService
+	metricService MetricsServiceInterface
 }
 
-func NewMetricsHandler(ms *mobile.MetricsService) *metricsHandler {
+func NewMetricsHandler(ms MetricsServiceInterface) *metricsHandler {
 	return &metricsHandler{metricService: ms}
 }
 

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -1,0 +1,145 @@
+package web
+
+import (
+	"testing"
+
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+	"github.com/stretchr/testify/assert"
+	mock "github.com/stretchr/testify/mock"
+)
+
+type MockMetricsService struct {
+	mock.Mock
+}
+
+func (m *MockMetricsService) Create(metric mobile.Metric) (mobile.Metric, error) {
+	args := m.Called(metric)
+	return args.Get(0).(mobile.Metric), args.Error(1)
+}
+
+func setupMetricsHandler(service MetricsServiceInterface) *httptest.Server {
+	router := NewRouter()
+	metricsHandler := NewMetricsHandler(service)
+	MetricsRoute(router, metricsHandler)
+	return httptest.NewServer(router)
+}
+
+func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
+	metric := mobile.Metric{
+		ClientTimestamp: 1234,
+		ClientId:        "client123",
+		Data: mobile.MetricData{
+			App: mobile.AppMetric{
+				ID:         "deadbeef",
+				SDKVersion: "1.2.3",
+				AppVersion: "27",
+			},
+			Device: mobile.DeviceMetric{
+				Platform:        "android",
+				PlatformVersion: "19",
+			},
+		},
+	}
+
+	byteBuffer := new(bytes.Buffer)
+	err := json.NewEncoder(byteBuffer).Encode(metric)
+	assert.Nil(t, err, "did not expect an error marshaling metric")
+
+	mockMetricsService := new(MockMetricsService)
+	mockMetricsService.On("Create", metric).Return(metric, nil)
+
+	s := setupMetricsHandler(mockMetricsService)
+	defer s.Close()
+
+	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
+	assert.Nil(t, err, "did not expect an error posting metrics")
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	assert.Equal(t, 200, res.StatusCode)
+
+	mockMetricsService.AssertExpectations(t)
+}
+
+func TestMetricsEndpointShouldReturn500WhenThereIsAnErrorInMetricsService(t *testing.T) {
+	metric := mobile.Metric{
+		ClientTimestamp: 1234,
+		ClientId:        "client123",
+		Data: mobile.MetricData{
+			App: mobile.AppMetric{
+				ID:         "deadbeef",
+				SDKVersion: "1.2.3",
+				AppVersion: "27",
+			},
+			Device: mobile.DeviceMetric{
+				Platform:        "android",
+				PlatformVersion: "19",
+			},
+		},
+	}
+
+	byteBuffer := new(bytes.Buffer)
+	err := json.NewEncoder(byteBuffer).Encode(metric)
+	assert.Nil(t, err, "did not expect an error marshaling metric")
+
+	mockMetricsService := new(MockMetricsService)
+	mockMetricsService.On("Create", metric).Return(mobile.Metric{}, errors.New("Metrics service error!")) // mock the service so that it returns an error
+
+	s := setupMetricsHandler(mockMetricsService)
+	defer s.Close()
+
+	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
+	assert.Nil(t, err, "did not expect an error posting metrics")
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	assert.Equal(t, 500, res.StatusCode)
+
+	mockMetricsService.AssertExpectations(t)
+}
+
+func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsEmpty(t *testing.T) {
+	mockMetricsService := new(MockMetricsService)
+
+	s := setupMetricsHandler(mockMetricsService)
+	defer s.Close()
+
+	res, err := http.Post(s.URL+"/metrics", "application/json", nil) // empty request body
+	assert.Nil(t, err, "did not expect an error posting metrics")
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	assert.Equal(t, 400, res.StatusCode)
+
+	mockMetricsService.AssertNotCalled(t, "Create")
+}
+
+func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsInvalidJSON(t *testing.T) {
+	mockMetricsService := new(MockMetricsService)
+
+	s := setupMetricsHandler(mockMetricsService)
+	defer s.Close()
+
+	byteBuffer := new(bytes.Buffer)
+	byteBuffer.WriteString("nonsense") // invalid JSON
+
+	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
+	assert.Nil(t, err, "did not expect an error posting metrics")
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	assert.Equal(t, 400, res.StatusCode)
+
+	mockMetricsService.AssertNotCalled(t, "Create")
+}

--- a/pkg/web/router.go
+++ b/pkg/web/router.go
@@ -23,7 +23,7 @@ func NewRouter() *mux.Router {
 }
 
 func MetricsRoute(r *mux.Router, handler *metricsHandler) {
-	r.HandleFunc("/default-metrics", handler.CreateMetric).Methods("POST")
+	r.HandleFunc("/metrics", handler.CreateMetric).Methods("POST")
 }
 
 func HealthzRoute(r *mux.Router, handler *healthHandler) {


### PR DESCRIPTION
- [x] initial connection and setup logic
- [x] Business logic for inserting records
- [x] Unit/Integration tests

## Update

This PR ended up turning into a mega PR but this is the initial implementation that allows us to store mobile metrics in the database. There are a number of things to be aware of:


* There is a small amount of validation. The incoming data is parsed into a struct which filters out unnecessary fields. additionally, there are some small checks at the DB layer. ClientId cannot be an empty string and by data field will not accept invalid json. There is no other validation (right now).
* Right now, the client timestamp is being parsed but not being saved. The `event_time` field is populated by Postgres at the time of insert.
* The db_test.go and dao_test.go are actually integration tests. However by default they will not run because of the `// +build integration` build tag added at the top of those files. You can run integration + unit tests using the standard test command, but also passing the flag `tags=integration` @maleck13 Not sure how you feel about this. I found this solution in this [stackoverflow answer](https://stackoverflow.com/questions/25965584/separating-unit-tests-and-integration-tests-in-go). I know it's not as clear as integration tests having their own folder but it's still fairly obvious by looking at the file that the test is an integration test.
* Removed references to timescaledb for now (as suggested by @david-martin )
* Still need to implement some standardised logging approach
* Docs need updating
* Code Coverage at a fairly good 87.6%

The original estimate was 4d and I've spent about 3 days on this so far so there's still time to do some housekeeping around docs, build process, release, etc etc.

## How to verify

fetch this branch and start the database using docker-compose.

Now start the server using `go run cmd/metrics-api/metrics-api.go`

You should see a message like

```
2018/02/22 17:28:30 Starting application... going to listen on :3000
```

Now you can try out the `/metrics` endpoint with the following curl request:

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 76a14738-976f-f0ea-4039-12efeebf4f1e' \
  -d '{
  "clientId": "12345",
  "data": {
  	"app": {
    "id": "com.example.someApp",
    "sdkVersion": "2.4.6",
    "appVersion": "256"
	},
	"device": {
    	"platform": "android",
    	"platformVersion": "27"
	}
  }
}'
```

You should get a the following response:

```
{"timestamp":0,"clientId":"12345","data":{"app":{"id":"com.example.someApp","sdkVersion":"2.4.6","appVersion":"256"},"device":{"platform":"android","platformVersion":"27"}}}
```

Note the `timestamp` field in the response corresponds to the client timestamp which is currently not being handled or saved.

You can log into the database and verify that the record was created:

```
psql -U postgres --host localhost
password: postgres

\c aerogear_mobile_metrics
select * from mobileappmetrics;

           clientid           |          event_time           |                                                                      data
------------------------------+-------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------
 org.aerogear.metrics.testing | 2018-02-22 15:14:03.859053+00 | {"app": {"id": "com.example.someApp", "appVersion": "256", "sdkVersion": "2.4.6"}, "device": {"platform": "android", "platformVersion": "27"}}
```

I'd love to get your reviews @maleck13 @david-martin @wtrocki 