### PR TITLE
AEROGEAR-2044 - HTTP Endpoint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,12 +35,6 @@
   revision = "88edab0803230a3898347e77b474f8c1820a1f20"
 
 [[projects]]
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
-
-[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "1.1.1"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
@@ -28,9 +34,38 @@
   ]
   revision = "88edab0803230a3898347e77b474f8c1820a1f20"
 
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  revision = "facf9a85c22f48d2f52f2380e4efce1768749a89"
+  version = "v0.1"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    ".",
+    "assert",
+    "http",
+    "mock"
+  ]
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9078497a83d301ee5230a5970fc382c993cde488695836a386d83d573a7baae3"
+  inputs-digest = "ae474b0b7e5cd65aff72004822c21f258738e4b3a5f03055ed12af1d36114c9c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,3 +40,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/lib/pq"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.2.1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,30 +1,3 @@
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#   name = "github.com/x/y"
-#   version = "2.4.0"
-#
-# [prune]
-#   non-go = false
-#   go-tests = true
-#   unused-packages = true
-
-
 [[constraint]]
   name = "github.com/darahayes/go-boom"
   version = "1.0.1"

--- a/pkg/web/interfaces.go
+++ b/pkg/web/interfaces.go
@@ -1,0 +1,7 @@
+package web
+
+import "github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+
+type MetricsServiceInterface interface {
+	Create(m mobile.Metric) (mobile.Metric, error)
+}

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -9,10 +9,10 @@ import (
 )
 
 type metricsHandler struct {
-	metricService *mobile.MetricsService
+	metricService MetricsServiceInterface
 }
 
-func NewMetricsHandler(ms *mobile.MetricsService) *metricsHandler {
+func NewMetricsHandler(ms MetricsServiceInterface) *metricsHandler {
 	return &metricsHandler{metricService: ms}
 }
 

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -34,14 +34,16 @@ func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
 	metric := mobile.Metric{
 		ClientTimestamp: 1234,
 		ClientId:        "client123",
-		App: mobile.AppMetric{
-			ID:         "deadbeef",
-			SDKVersion: "1.2.3",
-			AppVersion: "27",
-		},
-		Device: mobile.DeviceMetric{
-			Platform:        "android",
-			PlatformVersion: "19",
+		Data: mobile.MetricData{
+			App: mobile.AppMetric{
+				ID:         "deadbeef",
+				SDKVersion: "1.2.3",
+				AppVersion: "27",
+			},
+			Device: mobile.DeviceMetric{
+				Platform:        "android",
+				PlatformVersion: "19",
+			},
 		},
 	}
 
@@ -70,14 +72,16 @@ func TestMetricsEndpointShouldReturn500WhenThereIsAnErrorInMetricsService(t *tes
 	metric := mobile.Metric{
 		ClientTimestamp: 1234,
 		ClientId:        "client123",
-		App: mobile.AppMetric{
-			ID:         "deadbeef",
-			SDKVersion: "1.2.3",
-			AppVersion: "27",
-		},
-		Device: mobile.DeviceMetric{
-			Platform:        "android",
-			PlatformVersion: "19",
+		Data: mobile.MetricData{
+			App: mobile.AppMetric{
+				ID:         "deadbeef",
+				SDKVersion: "1.2.3",
+				AppVersion: "27",
+			},
+			Device: mobile.DeviceMetric{
+				Platform:        "android",
+				PlatformVersion: "19",
+			},
 		},
 	}
 

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -1,0 +1,141 @@
+package web
+
+import (
+	"testing"
+
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
+	"bytes"
+	"reflect"
+)
+
+type StubMetricsService struct {
+	recorded            mobile.Metric
+	createMethodInvoked bool
+}
+
+func (sms *StubMetricsService) Create(metric mobile.Metric) (mobile.Metric, error) {
+	sms.recorded = metric
+	sms.createMethodInvoked = true
+	return metric, nil
+}
+
+func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
+	metric := mobile.Metric{
+		ClientTimestamp: 1234,
+		ClientId:        "client123",
+		App: mobile.AppMetric{
+			ID:         "deadbeef",
+			SDKVersion: "1.2.3",
+			AppVersion: "27",
+		},
+		Device: mobile.DeviceMetric{
+			Platform:        "android",
+			PlatformVersion: "19",
+		},
+	}
+
+	byteBuffer := new(bytes.Buffer)
+	err := json.NewEncoder(byteBuffer).Encode(metric)
+
+	if err != nil {
+		t.Fatal("unable to marshal metric", err)
+	}
+
+	stubMetricsService := &StubMetricsService{}
+
+	router := NewRouter()
+	metricsHandler := NewMetricsHandler(stubMetricsService)
+	MetricsRoute(router, metricsHandler)
+	s := httptest.NewServer(router)
+	defer s.Close()
+	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
+	if err != nil {
+		t.Fatal("did not expect an error posting metrics", err)
+	}
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	if res.StatusCode != 200 {
+		t.Fatal("expected an 200 status")
+	}
+
+	if !stubMetricsService.createMethodInvoked {
+		t.Fatal("nothing sent to metrics service")
+	}
+
+	if !reflect.DeepEqual(stubMetricsService.recorded, metric) {
+		t.Fatal("unexpected metrics sent to metrics service")
+	}
+
+}
+
+func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsEmpty(t *testing.T) {
+	stubMetricsService := &StubMetricsService{}
+
+	router := NewRouter()
+	metricsHandler := NewMetricsHandler(stubMetricsService)
+	MetricsRoute(router, metricsHandler)
+	s := httptest.NewServer(router)
+	defer s.Close()
+	res, err := http.Post(s.URL+"/metrics", "application/json", nil)
+	if err != nil {
+		t.Fatal("did not expect an error posting metrics", err)
+	}
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	if res.StatusCode != 400 {
+		t.Fatal("expected an 400 status")
+	}
+
+	expected := mobile.Metric{}
+
+	if stubMetricsService.createMethodInvoked {
+		t.Fatal("shouldn't have interacted with metrics service")
+	}
+
+	if stubMetricsService.recorded != expected {
+		t.Fatal("unexpected metrics sent to metrics service")
+	}
+}
+
+func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsInvalidJSON(t *testing.T) {
+	stubMetricsService := &StubMetricsService{}
+
+	router := NewRouter()
+	metricsHandler := NewMetricsHandler(stubMetricsService)
+	MetricsRoute(router, metricsHandler)
+	s := httptest.NewServer(router)
+	defer s.Close()
+
+	byteBuffer := new(bytes.Buffer)
+	byteBuffer.WriteString("nonsense")
+
+	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
+	if err != nil {
+		t.Fatal("did not expect an error posting metrics", err)
+	}
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	if res.StatusCode != 400 {
+		t.Fatal("expected an 400 status")
+	}
+
+	expected := mobile.Metric{}
+
+	if stubMetricsService.createMethodInvoked {
+		t.Fatal("shouldn't have interacted with metrics service")
+	}
+
+	if stubMetricsService.recorded != expected {
+		t.Fatal("unexpected metrics sent to metrics service")
+	}
+}

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -7,11 +7,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 	"bytes"
+	"errors"
+	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/assert"
-	"github.com/pkg/errors"
 )
 
 type MockMetricsService struct {

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 	"bytes"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/assert"
 	"github.com/pkg/errors"
 )
 
@@ -46,10 +47,7 @@ func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
 
 	byteBuffer := new(bytes.Buffer)
 	err := json.NewEncoder(byteBuffer).Encode(metric)
-
-	if err != nil {
-		t.Fatal("unable to marshal metric", err)
-	}
+	assert.Nil(t, err, "did not expect an error marshaling metric")
 
 	mockMetricsService := new(MockMetricsService)
 	mockMetricsService.On("Create", metric).Return(metric, nil)
@@ -58,16 +56,12 @@ func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
 	defer s.Close()
 
 	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
-	if err != nil {
-		t.Fatal("did not expect an error posting metrics", err)
-	}
+	assert.Nil(t, err, "did not expect an error posting metrics")
 
 	defer res.Body.Close()
 	_, err = ioutil.ReadAll(res.Body)
 
-	if res.StatusCode != 200 {
-		t.Fatal("expected a 200 status")
-	}
+	assert.Equal(t, 200, res.StatusCode)
 
 	mockMetricsService.AssertExpectations(t)
 }
@@ -89,28 +83,21 @@ func TestMetricsEndpointShouldReturn500WhenThereIsAnErrorInMetricsService(t *tes
 
 	byteBuffer := new(bytes.Buffer)
 	err := json.NewEncoder(byteBuffer).Encode(metric)
-
-	if err != nil {
-		t.Fatal("unable to marshal metric", err)
-	}
+	assert.Nil(t, err, "did not expect an error marshaling metric")
 
 	mockMetricsService := new(MockMetricsService)
-	mockMetricsService.On("Create", metric).Return(mobile.Metric{}, errors.New("Metrics service error!"))		// mock the service so that it returns an error
+	mockMetricsService.On("Create", metric).Return(mobile.Metric{}, errors.New("Metrics service error!")) // mock the service so that it returns an error
 
 	s := setupMetricsHandler(mockMetricsService)
 	defer s.Close()
 
 	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
-	if err != nil {
-		t.Fatal("did not expect an error posting metrics", err)
-	}
+	assert.Nil(t, err, "did not expect an error posting metrics")
 
 	defer res.Body.Close()
 	_, err = ioutil.ReadAll(res.Body)
 
-	if res.StatusCode != 500 {
-		t.Fatal("expected a 500 status")
-	}
+	assert.Equal(t, 500, res.StatusCode)
 
 	mockMetricsService.AssertExpectations(t)
 }
@@ -122,16 +109,12 @@ func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsEmpt
 	defer s.Close()
 
 	res, err := http.Post(s.URL+"/metrics", "application/json", nil) // empty request body
-	if err != nil {
-		t.Fatal("did not expect an error posting metrics", err)
-	}
+	assert.Nil(t, err, "did not expect an error posting metrics")
 
 	defer res.Body.Close()
 	_, err = ioutil.ReadAll(res.Body)
 
-	if res.StatusCode != 400 {
-		t.Fatal("expected a 400 status")
-	}
+	assert.Equal(t, 400, res.StatusCode)
 
 	mockMetricsService.AssertNotCalled(t, "Create")
 }
@@ -146,16 +129,12 @@ func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsInva
 	byteBuffer.WriteString("nonsense") // invalid JSON
 
 	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
-	if err != nil {
-		t.Fatal("did not expect an error posting metrics", err)
-	}
+	assert.Nil(t, err, "did not expect an error posting metrics")
 
 	defer res.Body.Close()
 	_, err = ioutil.ReadAll(res.Body)
 
-	if res.StatusCode != 400 {
-		t.Fatal("expected a 400 status")
-	}
+	assert.Equal(t, 400, res.StatusCode)
 
 	mockMetricsService.AssertNotCalled(t, "Create")
 }

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aerogear/aerogear-metrics-api/pkg/mobile"
 	"bytes"
 	"github.com/stretchr/testify/mock"
+	"github.com/pkg/errors"
 )
 
 type MockMetricsService struct {
@@ -65,7 +66,50 @@ func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
 	_, err = ioutil.ReadAll(res.Body)
 
 	if res.StatusCode != 200 {
-		t.Fatal("expected an 200 status")
+		t.Fatal("expected a 200 status")
+	}
+
+	mockMetricsService.AssertExpectations(t)
+}
+
+func TestMetricsEndpointShouldReturn500WhenThereIsAnErrorInMetricsService(t *testing.T) {
+	metric := mobile.Metric{
+		ClientTimestamp: 1234,
+		ClientId:        "client123",
+		App: mobile.AppMetric{
+			ID:         "deadbeef",
+			SDKVersion: "1.2.3",
+			AppVersion: "27",
+		},
+		Device: mobile.DeviceMetric{
+			Platform:        "android",
+			PlatformVersion: "19",
+		},
+	}
+
+	byteBuffer := new(bytes.Buffer)
+	err := json.NewEncoder(byteBuffer).Encode(metric)
+
+	if err != nil {
+		t.Fatal("unable to marshal metric", err)
+	}
+
+	mockMetricsService := new(MockMetricsService)
+	mockMetricsService.On("Create", metric).Return(mobile.Metric{}, errors.New("Metrics service error!"))		// mock the service so that it returns an error
+
+	s := setupMetricsHandler(mockMetricsService)
+	defer s.Close()
+
+	res, err := http.Post(s.URL+"/metrics", "application/json", byteBuffer)
+	if err != nil {
+		t.Fatal("did not expect an error posting metrics", err)
+	}
+
+	defer res.Body.Close()
+	_, err = ioutil.ReadAll(res.Body)
+
+	if res.StatusCode != 500 {
+		t.Fatal("expected a 500 status")
 	}
 
 	mockMetricsService.AssertExpectations(t)
@@ -86,7 +130,7 @@ func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsEmpt
 	_, err = ioutil.ReadAll(res.Body)
 
 	if res.StatusCode != 400 {
-		t.Fatal("expected an 400 status")
+		t.Fatal("expected a 400 status")
 	}
 
 	mockMetricsService.AssertNotCalled(t, "Create")
@@ -110,7 +154,7 @@ func TestMetricsEndpointShouldNotInteractWithMetricsServiceWhenRequestBodyIsInva
 	_, err = ioutil.ReadAll(res.Body)
 
 	if res.StatusCode != 400 {
-		t.Fatal("expected an 400 status")
+		t.Fatal("expected a 400 status")
 	}
 
 	mockMetricsService.AssertNotCalled(t, "Create")


### PR DESCRIPTION
As HTTP endpoint is already created part of https://github.com/aerogear/aerogear-metrics-api/pull/10, this PR only implements tests for it.

This PR is blocked by https://github.com/aerogear/aerogear-metrics-api/pull/10

As we don't have the DB integration working yet, we cannot do E2E tests.
Thus, we decided to write some unit tests for the endpoint only. 

Tests for the endpoint handler shouldn't call `MetricsService` for real as it is not functioning properly. So, we created a "mock" for that service and passed it to the endpoint handler.

The value gained from the unit test is actually very little. It just checks if the mocked service is called with right parameters in the happy case. In the bad cases (invalid JSON or empty request body), the test verifies that nothing sent to the service layer and a 400 is returned.
But, this is a good chance to start something simple with Golang.
