### PR TITLE
fix: Dockerfile uses a pre built binary as an argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/
 .idea/
 metrics
+metrics_linux_amd_64
 dist/

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,17 +1,9 @@
-FROM golang:latest
+FROM centos:latest
 
-RUN mkdir -p /go/src/github.com/aerogear/aerogear-metrics-api/
+ARG BINARY=./metrics
+
 RUN mkdir /metrics-api
 
-ADD . /go/src/github.com/aerogear/aerogear-metrics-api/
-
-WORKDIR /go/src/github.com/aerogear/aerogear-metrics-api/
-
-RUN go get github.com/golang/dep/cmd/dep
-RUN dep ensure
-
-RUN go build -o /metrics-api/metrics-api ./cmd/metrics-api/metrics-api.go
-
-RUN ls /metrics-api
+ADD ${BINARY} /metrics-api/metrics-api
 
 CMD ["/metrics-api/metrics-api"]

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ TEST_DIRS     ?= $(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go \
 BIN_DIR := $(GOPATH)/bin
 SHELL = /bin/bash
 BINARY = metrics
+LINUX_BINARY = metrics_linux_amd_64
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 
@@ -17,11 +18,15 @@ build: setup build_binary
 
 .PHONY: build_binary_linux
 build_binary_linux:
-	env GOOS=linux GOARCH=amd64 go build -o $(BINARY) ./cmd/metrics-api/metrics-api.go
+	env GOOS=linux GOARCH=amd64 go build -o $(LINUX_BINARY) ./cmd/metrics-api/metrics-api.go
 
 .PHONY: build_binary
 build_binary:
 	go build -o $(BINARY) ./cmd/metrics-api/metrics-api.go
+
+.PHONY: docker_build
+docker_build: setup build_binary_linux
+	docker build -t aerogear-metrics-api --build-arg BINARY=$(LINUX_BINARY)  -f deployments/docker/Dockerfile .
 
 .PHONY: test-unit
 test-unit:

--- a/makefile
+++ b/makefile
@@ -6,6 +6,7 @@ BIN_DIR := $(GOPATH)/bin
 SHELL = /bin/bash
 BINARY = metrics
 LINUX_BINARY = metrics_linux_amd_64
+IMAGE_NAME = aerogear/aerogear-metrics-api
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${TAG}"
 
@@ -26,7 +27,7 @@ build_binary:
 
 .PHONY: docker_build
 docker_build: setup build_binary_linux
-	docker build -t aerogear-metrics-api --build-arg BINARY=$(LINUX_BINARY)  -f deployments/docker/Dockerfile .
+	docker build -t $(IMAGE_NAME) --build-arg BINARY=$(LINUX_BINARY)  -f deployments/docker/Dockerfile .
 
 .PHONY: test-unit
 test-unit:


### PR DESCRIPTION
This PR changes the Dockerfile to accept an ARG called BINARY. This arg should be the path to a pre built binary.

This simple approach allows us to build a docker image using local source code but will also allow us to build docker images from official releases (from Github).

The local developer/contributor will have a process as follows:

* Clone the code
* Run `make docker_build` - This will build a binary from source and then start the Docker build passing in the binary

The release process will be as follows:

* Run `make release` - This will generate a release in Github with the following artefacts:
	* a number of binaries (linux, OSX, whatever is suitable)
	* Source Code tar files
* Run `make docker_build_release` - This will download the linux binary from the official release in Github and start the Docker build passing in the release binary. The image will be tagged appropriately
* Run `make docker_push_release` - This will push the newly built release image

^^ note it will be possible to simply run `make docker_push_release` and the depended upon steps will be run first.

There are several advantages to this approach:

* Dockerfile and resulting image is tiny
* It's incredibly simple and developer friendly
* It can be done on developer machines or in CI
* Builds from any time in the past are 100% reproducible