### PR TITLE
using os.Lookup instead of Getenv

### DIFF
--- a/cmd/metrics-api/metrics-api.go
+++ b/cmd/metrics-api/metrics-api.go
@@ -14,7 +14,7 @@ func main() {
 
 	// Simple helper function to read an environment or return a default value
 	getEnv := func(key string, defaultVal string) string {
-		if value := os.Getenv(key); value != "" {
+		if value, ok := os.LookupEnv(key); ok {
 			return value
 		}
 		return defaultVal


### PR DESCRIPTION
## Motivation

using `os.Lookup` to avoid string comparison. `bool` is `true` if ENV is set

## Description

## Progress

- [x] Done Task
- [ ] Todo Task

