### PR TITLE
feat: add some very basic validation to Metric struct

### DIFF
--- a/pkg/mobile/metrics_test.go
+++ b/pkg/mobile/metrics_test.go
@@ -30,13 +30,13 @@ func TestCreateCallsDAOWithCorrectArgs(t *testing.T) {
 
 	metric := Metric{
 		ClientId: "org.aerogear.metrics.tests",
-		Data: MetricData{
-			App: AppMetric{
+		Data: &MetricData{
+			App: &AppMetric{
 				ID:         "12345678",
 				SDKVersion: "1.0.0",
 				AppVersion: "1",
 			},
-			Device: DeviceMetric{
+			Device: &DeviceMetric{
 				Platform:        "Android",
 				PlatformVersion: "27",
 			},
@@ -69,13 +69,13 @@ func TestCreateReturnsErrorFromDAO(t *testing.T) {
 
 	metric := Metric{
 		ClientId: "org.aerogear.metrics.tests",
-		Data: MetricData{
-			App: AppMetric{
+		Data: &MetricData{
+			App: &AppMetric{
 				ID:         "12345678",
 				SDKVersion: "1.0.0",
 				AppVersion: "1",
 			},
-			Device: DeviceMetric{
+			Device: &DeviceMetric{
 				Platform:        "Android",
 				PlatformVersion: "27",
 			},

--- a/pkg/mobile/types.go
+++ b/pkg/mobile/types.go
@@ -7,14 +7,14 @@ type AppConfig struct {
 // ClientMetric struct is what the client payload should be parsed into
 // Need to figure out how to structure this
 type Metric struct {
-	ClientTimestamp int64      `json:"timestamp"`
-	ClientId        string     `json:"clientId"`
-	Data            MetricData `json:"data"`
+	ClientTimestamp int64       `json:"timestamp,omitempty"`
+	ClientId        string      `json:"clientId"`
+	Data            *MetricData `json:"data,omitempty"`
 }
 
 type MetricData struct {
-	App    AppMetric    `json:"app"`
-	Device DeviceMetric `json:"device"`
+	App    *AppMetric    `json:"app,omitempty"`
+	Device *DeviceMetric `json:"device,omitempty"`
 }
 
 type AppMetric struct {
@@ -26,4 +26,16 @@ type AppMetric struct {
 type DeviceMetric struct {
 	Platform        string `json:"platform"`
 	PlatformVersion string `json:"platformVersion"`
+}
+
+func (m *Metric) Validate() (valid bool, reason string) {
+	if m.ClientId == "" {
+		return false, "missing clientId in payload"
+	}
+
+	// check if data field was missing or empty object
+	if m.Data == nil || (MetricData{}) == *m.Data {
+		return false, "missing metrics data in payload"
+	}
+	return true, ""
 }

--- a/pkg/mobile/types_test.go
+++ b/pkg/mobile/types_test.go
@@ -1,0 +1,59 @@
+package mobile
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMetricValidate(t *testing.T) {
+
+	testCases := []struct {
+		Name           string
+		Metric         Metric
+		Valid          bool
+		ExpectedReason string
+	}{
+		{
+			Name:           "Empty metric should be invalid",
+			Metric:         Metric{},
+			Valid:          false,
+			ExpectedReason: "missing clientId in payload",
+		},
+		{
+			Name:           "Metric with no clientId should be invalid",
+			Metric:         Metric{Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Valid:          false,
+			ExpectedReason: "missing clientId in payload",
+		},
+		{
+			Name:           "Metric with no Data should be invalid",
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing"},
+			Valid:          false,
+			ExpectedReason: "missing metrics data in payload",
+		},
+		{
+			Name:           "Metric with empty Data should be invalid",
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{}},
+			Valid:          false,
+			ExpectedReason: "missing metrics data in payload",
+		},
+		{
+			Name:           "Metric with ClientId and Some Data should be valid",
+			Metric:         Metric{ClientId: "org.aerogear.metrics.testing", Data: &MetricData{App: &AppMetric{SDKVersion: "1"}}},
+			Valid:          true,
+			ExpectedReason: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		valid, reason := tc.Metric.Validate()
+
+		if valid != tc.Valid {
+			fmt.Errorf("case failed: %s. Expected: %v, got %v", tc.Name, tc.Valid, valid)
+		}
+
+		if reason != tc.ExpectedReason {
+			fmt.Errorf("case failed: %s. Expected: %v, got %v", tc.Name, tc.ExpectedReason, reason)
+		}
+	}
+}

--- a/pkg/web/metricsHandler.go
+++ b/pkg/web/metricsHandler.go
@@ -27,6 +27,11 @@ func (mh *metricsHandler) CreateMetric(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if valid, reason := metric.Validate(); !valid {
+		boom.BadRequest(w, reason)
+		return
+	}
+
 	// create the record in the db
 	result, err := mh.metricService.Create(metric)
 

--- a/pkg/web/metricsHandler_test.go
+++ b/pkg/web/metricsHandler_test.go
@@ -35,13 +35,13 @@ func TestMetricsEndpointShouldPassReceivedDataToMetricsService(t *testing.T) {
 	metric := mobile.Metric{
 		ClientTimestamp: 1234,
 		ClientId:        "client123",
-		Data: mobile.MetricData{
-			App: mobile.AppMetric{
+		Data: &mobile.MetricData{
+			App: &mobile.AppMetric{
 				ID:         "deadbeef",
 				SDKVersion: "1.2.3",
 				AppVersion: "27",
 			},
-			Device: mobile.DeviceMetric{
+			Device: &mobile.DeviceMetric{
 				Platform:        "android",
 				PlatformVersion: "19",
 			},
@@ -73,13 +73,13 @@ func TestMetricsEndpointShouldReturn500WhenThereIsAnErrorInMetricsService(t *tes
 	metric := mobile.Metric{
 		ClientTimestamp: 1234,
 		ClientId:        "client123",
-		Data: mobile.MetricData{
-			App: mobile.AppMetric{
+		Data: &mobile.MetricData{
+			App: &mobile.AppMetric{
 				ID:         "deadbeef",
 				SDKVersion: "1.2.3",
 				AppVersion: "27",
 			},
-			Device: mobile.DeviceMetric{
+			Device: &mobile.DeviceMetric{
 				Platform:        "android",
 				PlatformVersion: "19",
 			},


### PR DESCRIPTION
## Description

This PR adds a function `Validate() (valid bool, reason string)` to the Metric struct and uses that function in the metrics handler to check for some basic validation cases. clientId not existing and Data not existing or being empty object.

This prevents us from saving empty entries in postgres. Unit tests have been added for the Validate() function.

## Verification steps

I've constructed some curl requests and expected responses so you can try out. For now the server returns the same data that is saved in the DB. This is handy in development.

## Case 1
The happy case - full payload. (Excluding client timestamp - will look after this in a separate PR) 
```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 77100fc4-f06a-7098-69e4-dfdcaa207e98' \
  -d '{
  "clientId": "12345",
  "data": {
  	"app": {
    "id": "com.example.someApp",
    "sdkVersion": "2.4.6",
    "appVersion": "256"
	},
	"device": {
    	"platform": "android",
    	"platformVersion": "27"
	}
  }
}'
```

result:

```
{
    "clientId": "12345",
    "data": {
        "app": {
            "id": "com.example.someApp",
            "sdkVersion": "2.4.6",
            "appVersion": "256"
        },
        "device": {
            "platform": "android",
            "platformVersion": "27"
        }
    }
}
```

## Case 2

app data is included but not device metrics. i.e. only a subset of all possible fields, but still valid.

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 2ba02c83-8ba8-7b3b-2ddf-c63de048cb8d' \
  -d '{
  "clientId": "12345",
  "data": {
  	"app": {
    "id": "com.example.someApp",
    "sdkVersion": "2.4.6",
    "appVersion": "256"
	}
  }
}'
```

result:

```
{
    "clientId": "12345",
    "data": {
        "app": {
            "id": "com.example.someApp",
            "sdkVersion": "2.4.6",
            "appVersion": "256"
        }
    }
}
```

## Case 3

Client sends an empty object:

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 2fd4aa64-43ad-a168-3c57-3c31b250b0ba' \
  -d '{
  
}'
```

Result:

```
{
    "error": "Bad Request",
    "message": "missing clientId in payload",
    "statusCode": 400
}
```

## Case 4

Data field is not included

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 3d3c1945-d191-55e4-0b52-eeffbdb64afc' \
  -d '{
  "clientId": "12345"
}'
```

result: 

```
{
    "error": "Bad Request",
    "message": "missing metrics data in payload",
    "statusCode": 400
}
```


## Case 5

Data field is there but empty object

```
curl -X POST \
  http://localhost:3000/metrics \
  -H 'Cache-Control: no-cache' \
  -H 'Content-Type: application/json' \
  -H 'Postman-Token: 3d3c1945-d191-55e4-0b52-eeffbdb64afc' \
  -d '{
  "clientId": "12345",
  "data": {
  	
  }
}'
```

result: 

```
{
    "error": "Bad Request",
    "message": "missing metrics data in payload",
    "statusCode": 400
}
```




