### PR TITLE
fix(tests): ensure integration tests use config pkg properly

### DIFF
--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ test-integration:
 test-integration-cover:
 	echo "mode: count" > coverage-all.out
 	$(foreach pkg,$(PACKAGES),\
-		go test -tags=integration -coverprofile=coverage.out -covermode=count $(addprefix $(PKG)/,$(pkg));\
+		go test -tags=integration -coverprofile=coverage.out -covermode=count $(addprefix $(PKG)/,$(pkg)) || exit 1;\
 		tail -n +2 coverage.out >> coverage-all.out;)
 
 .PHONY: errcheck

--- a/pkg/dao/dao_test.go
+++ b/pkg/dao/dao_test.go
@@ -17,7 +17,7 @@ func TestIsHealthy(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -40,7 +40,7 @@ func TestIsHealthyWhenDisconnected(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -65,7 +65,7 @@ func TestCreate(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -93,7 +93,7 @@ func TestCreateBadJSON(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -115,7 +115,7 @@ func TestCreateEmptyClientID(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())

--- a/pkg/dao/db_test.go
+++ b/pkg/dao/db_test.go
@@ -12,7 +12,7 @@ func TestConnect(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -29,13 +29,13 @@ func TestConnectAlreadyConnected(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
 	}
 
-	err = dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err = dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -46,7 +46,7 @@ func TestDisconnect(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())
@@ -79,7 +79,7 @@ func TestDoInitialSetup(t *testing.T) {
 	config := config.GetConfig()
 	dbHandler := DatabaseHandler{}
 
-	err := dbHandler.Connect(config.DBHost, config.DBUser, config.DBPassword, config.DBName, config.SSLMode)
+	err := dbHandler.Connect(config["DBHost"], config["DBUser"], config["DBPassword"], config["DBName"], config["SSLMode"])
 
 	if err != nil {
 		t.Errorf("Connect() returned an error: %s", err.Error())


### PR DESCRIPTION
The config pkg was refactored to use a map as opposed to a struct. The integration tests were not updated to reflect the change. We never noticed the build failing because the `make test-integration-cover` command is using a `foreach` syntax that wasn't returning a non-zero exit code. The make command has been updated to ensure a failing test will cause `make` to fail properly.

ping @psturc thanks for catching this.